### PR TITLE
Add OCR step before LLM processing

### DIFF
--- a/Clerk/Services/OCRService.swift
+++ b/Clerk/Services/OCRService.swift
@@ -1,0 +1,24 @@
+import UIKit
+import Vision
+
+struct OCRService {
+    static func recognizeText(from images: [UIImage]) throws -> String {
+        var fullText = ""
+        for image in images {
+            guard let cgImage = image.cgImage else { continue }
+            let request = VNRecognizeTextRequest()
+            request.recognitionLevel = .accurate
+            request.usesLanguageCorrection = true
+            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+            try handler.perform([request])
+            if let observations = request.results as? [VNRecognizedTextObservation] {
+                for observation in observations {
+                    if let candidate = observation.topCandidates(1).first {
+                        fullText += candidate.string + "\n"
+                    }
+                }
+            }
+        }
+        return fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Clerk/Views/FileSystemView.swift
+++ b/Clerk/Views/FileSystemView.swift
@@ -5,6 +5,8 @@ import DocumentScannerView
 import QuickLook
 import UniformTypeIdentifiers
 import PhotosUI
+import Vision
+
 
 class DragState: ObservableObject {
     @Published var isDraggingOver = false
@@ -419,11 +421,12 @@ struct FileSystemView: View {
             isProcessingDocument = true
             let document = ScannedDocument(images: images)
             currentDocument = document
-            
+
             do {
+                let recognizedText = try OCRService.recognizeText(from: images)
                 let allFolders = (try? modelContext.fetch(FetchDescriptor<FolderItem>())) ?? []
                 let (summary, title, folderSuggestion, documentType, requiredAction) = try await LLMService.analyzeDocument(
-                    images: images,
+                    text: recognizedText,
                     existingFolders: allFolders
                 )
                 document.llmSummary = summary


### PR DESCRIPTION
## Summary
- add `OCRService` for running `VNRecognizeTextRequest`
- add text-based `LLMService.analyzeDocument` variant
- run OCR before analyzing document and send text to LLM

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6851c6ef7adc83298be1d7555a8a7b7d